### PR TITLE
DTO-161 Feat: 회원가입 검증 로직 구현 완료

### DIFF
--- a/src/main/java/com/dto/way/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/dto/way/member/domain/repository/MemberRepository.java
@@ -9,4 +9,8 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/dto/way/member/web/controller/MemberRestController.java
+++ b/src/main/java/com/dto/way/member/web/controller/MemberRestController.java
@@ -1,16 +1,16 @@
 package com.dto.way.member.web.controller;
 
 import com.dto.way.member.domain.service.MemberService;
-import com.dto.way.member.domain.service.RedisService;
 import com.dto.way.member.web.dto.JwtToken;
 import com.dto.way.member.web.response.ApiResponse;
-import com.dto.way.member.web.response.code.status.ErrorStatus;
-import com.dto.way.member.web.response.code.status.SuccessStatus;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import static com.dto.way.member.web.dto.MemberRequestDto.*;
+import static com.dto.way.member.web.response.code.status.SuccessStatus.*;
+import static com.dto.way.member.web.response.code.status.ErrorStatus.*;
 
 @Slf4j
 @RestController
@@ -21,17 +21,29 @@ public class MemberRestController {
     private final MemberService memberService;
 
     @PostMapping("/signUp")
-    public ApiResponse<CreateMemberRequestDto> signUp(@RequestBody CreateMemberRequestDto createMemberRequestDto) {
+    public ApiResponse<CreateMemberRequestDto> signUp(@Valid @RequestBody CreateMemberRequestDto createMemberRequestDto) {
 
-        if (memberService.createMember(createMemberRequestDto)) { // 회원가입에 성공한 경우
-            return ApiResponse.of(SuccessStatus.MEMBER_SIGNUP, createMemberRequestDto);
-        } else { // 회원가입에 실패한 경우
-            return ApiResponse.onFailure(ErrorStatus.MEMBER_NICKNAME_DUPLICATED.getCode(), "회원가입 실패", createMemberRequestDto);
+        String result = memberService.createMember(createMemberRequestDto);
+
+        if (result.equals(MEMBER_SIGNUP.getCode())) { // 회원가입에 성공한 경우
+            return ApiResponse.of(MEMBER_SIGNUP, createMemberRequestDto);
+        }
+
+        else if (result.equals(MEMBER_EMAIL_DUPLICATED.getCode())) { // 이메일 중복인 경우
+            return ApiResponse.onFailure(MEMBER_EMAIL_DUPLICATED.getCode(), MEMBER_EMAIL_DUPLICATED.getMessage(), createMemberRequestDto);
+        }
+
+        else if (result.equals(MEMBER_NICKNAME_DUPLICATED.getCode())) { // 닉네임 중복인 경우
+            return ApiResponse.onFailure(MEMBER_NICKNAME_DUPLICATED.getCode(), MEMBER_NICKNAME_DUPLICATED.getMessage(), createMemberRequestDto);
+        }
+
+        else { // 비밀번호가 일치하지 않는 경우
+            return ApiResponse.onFailure(MEMBER_PASSWORD_NOT_MATCHED.getCode(), MEMBER_PASSWORD_NOT_MATCHED.getMessage(), createMemberRequestDto);
         }
     }
 
     @PostMapping("/login")
-    public JwtToken login(@RequestBody LoginMemberRequestDto loginMemberRequestDto) {
+    public ApiResponse<JwtToken> login(@Valid @RequestBody LoginMemberRequestDto loginMemberRequestDto) {
 
         JwtToken jwtToken = memberService.login(loginMemberRequestDto);
         log.info("==========USER INFO==========");
@@ -39,16 +51,15 @@ public class MemberRestController {
         log.info("==========JWT TOKEN==========");
         log.info("Access Token = {} ", jwtToken.getAccessToken());
         log.info("Refresh Token = {} ", jwtToken.getRefreshToken());
-
-
-        return jwtToken;
+        
+        return ApiResponse.of(MEMBER_LOGIN, jwtToken);
     }
 
     @PostMapping("/logout")
     public ApiResponse<JwtToken> logout(@RequestBody JwtToken jwtToken) {
         memberService.logout(jwtToken);
 
-        return ApiResponse.of(SuccessStatus.MEMBER_LOGOUT, jwtToken);
+        return ApiResponse.of(MEMBER_LOGOUT, jwtToken);
     }
 
     @PostMapping("/testJwtToken")

--- a/src/main/java/com/dto/way/member/web/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/dto/way/member/web/response/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "MEMBER4002", "중복된 닉네임 입니다."),
     MEMBER_PASSWORD_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBER4003", "유효한 비밀번호가 아닙니다."),
     MEMBER_PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "MEMBER4004", "비밀번호가 일치하지 않습니다."),
+    MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "MEMBER4005", "해당 이메일로 가입한 계정이 존재합니다."),
 
     ;
 


### PR DESCRIPTION

## 📌 요약

---
- 회원가입 필드에 대한 검증 로직 구현이 완료되었습니다.

## #️⃣ Issue Number or Link

---
DTO-161

## 📋 상세 내용

---
- 이메일 중복, 닉네임 중복, 비밀번호 일치 검사는 memberService에 로직을 구현했습니다.
- 그 외의 필드값에 대한 검증은 @Valid로 구현하고 handleMethodArgumentNotValid로 처리했습니다.


## ❓기타 문의사항

---

## ✔️PR Checklist 

---

PR이 다음 요구 사항을 충족하는지 확인하세요.

> Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
