### PR TITLE
DTO-261 Feat: 로그인 검증 로직 구현 완료

### DIFF
--- a/src/main/java/com/dto/way/member/domain/service/MemberService.java
+++ b/src/main/java/com/dto/way/member/domain/service/MemberService.java
@@ -71,6 +71,15 @@ public class MemberService {
     }
 
     public JwtToken login(LoginMemberRequestDto loginMemberRequestDto) {
+        Optional<Member> member = memberRepository.findByEmail(loginMemberRequestDto.getEmail());
+        if (member.isEmpty()) {
+            return new JwtToken(MEMBER_LOGIN_FAILED.getCode(), null, null);
+        } else {
+            if (!member.get().getPassword().equals(loginMemberRequestDto.getPassword())) {
+                return new JwtToken(MEMBER_LOGIN_FAILED.getCode(), null, null);
+            }
+        }
+
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginMemberRequestDto.getEmail(), loginMemberRequestDto.getPassword());
 
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);

--- a/src/main/java/com/dto/way/member/web/controller/MemberRestController.java
+++ b/src/main/java/com/dto/way/member/web/controller/MemberRestController.java
@@ -46,11 +46,10 @@ public class MemberRestController {
     public ApiResponse<JwtToken> login(@Valid @RequestBody LoginMemberRequestDto loginMemberRequestDto) {
 
         JwtToken jwtToken = memberService.login(loginMemberRequestDto);
-        log.info("==========USER INFO==========");
-        log.info("email = {} ", loginMemberRequestDto.getEmail());
-        log.info("==========JWT TOKEN==========");
-        log.info("Access Token = {} ", jwtToken.getAccessToken());
-        log.info("Refresh Token = {} ", jwtToken.getRefreshToken());
+
+        if (jwtToken.getGrantType().equals(MEMBER_LOGIN_FAILED.getCode())) {
+            return ApiResponse.onFailure(MEMBER_LOGIN_FAILED.getCode(), MEMBER_LOGIN_FAILED.getMessage(), jwtToken);
+        }
         
         return ApiResponse.of(MEMBER_LOGIN, jwtToken);
     }

--- a/src/main/java/com/dto/way/member/web/dto/MemberRequestDto.java
+++ b/src/main/java/com/dto/way/member/web/dto/MemberRequestDto.java
@@ -44,6 +44,8 @@ public class MemberRequestDto {
         private String email;
 
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+                message = "영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호를 입력해주세요.")
         private String password;
     }
 }

--- a/src/main/java/com/dto/way/member/web/exception/ExceptionAdvice.java
+++ b/src/main/java/com/dto/way/member/web/exception/ExceptionAdvice.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/dto/way/member/web/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/dto/way/member/web/response/code/status/ErrorStatus.java
@@ -16,13 +16,15 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    // 이 곳에 응답을 추가합니다.
+    // 회원가입 응답
     MEMBER_NICKNAME_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBER4001", "유효한 닉네임이 아닙니다."),
     MEMBER_NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "MEMBER4002", "중복된 닉네임 입니다."),
     MEMBER_PASSWORD_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBER4003", "유효한 비밀번호가 아닙니다."),
     MEMBER_PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "MEMBER4004", "비밀번호가 일치하지 않습니다."),
     MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "MEMBER4005", "해당 이메일로 가입한 계정이 존재합니다."),
 
+    // 로그인 응답
+    MEMBER_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "MEMBER40010", "아이디 또는 비밀번호가 일치하지 않습니다."),
     ;
 
 


### PR DESCRIPTION


## 📌 요약

---
- 로그인 검증 구현이 완료되었습니다.

## #️⃣ Issue Number or Link

---
DTO-261

## 📋 상세 내용

---
- 아이디 혹은 비밀번호가 틀릴 경우 로그인 실패 코드를 반환합니다.
- 아이디가 틀린 것인지, 비밀번호가 틀린 것인지는 반환하지 않습니다.

## ❓기타 문의사항

---

## ✔️PR Checklist 

---

PR이 다음 요구 사항을 충족하는지 확인하세요.

> Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
