### PR TITLE
DTO-159 Feat: 이메일 인증 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/dto/way/member/domain/service/MailService.java
+++ b/src/main/java/com/dto/way/member/domain/service/MailService.java
@@ -1,0 +1,72 @@
+package com.dto.way.member.domain.service;
+
+import com.dto.way.member.global.CertificationGenerator;
+import com.dto.way.member.web.response.EmailCertificationResponse;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private final CertificationGenerator certificationGenerator;
+    private final RedisService redisService;
+
+    public EmailCertificationResponse sendEmailForCertification(String email) throws NoSuchAlgorithmException, MessagingException {
+
+        String certificationNumber = certificationGenerator.createCertificationNumber();
+        String content = String.format("%s/member-service/verify?certificationNumber=%s&email=%s   해당 링크로 10분 이내에 접속해주세요.", "localhost:8080", certificationNumber, email);
+
+        saveEmailInRedis(email, certificationNumber);
+
+        try {
+            sendMail(email, content);
+            return new EmailCertificationResponse(email, certificationNumber);
+        } catch (MessagingException e) { // 메일 전송에 실패한 경우
+            log.error("메일 전송 실패! 유효하지 않은 이메일: {}", email);
+            throw e;
+        }
+    }
+
+    private void saveEmailInRedis(String email, String certificationNumber) {
+        if (redisService.getValues(email).isEmpty()) { // redis 안에 이메일 키가 없다면
+            redisService.setValues(email, certificationNumber, Duration.ofMinutes(10));
+        } else { // redis 안에 이메일 키가 있다면 -> 이미 인증번호 요청을 한 상태이기 때문에 데이터를 삭제하고 다시 만든다.
+            redisService.deleteValues(email);
+            redisService.setValues(email, certificationNumber, Duration.ofMinutes(10));
+        }
+    }
+
+    // 이메일과 인증번호가 일치하는지 검증
+    public boolean verifyEmail(String email, String certificationNumber) {
+        String value = redisService.getValues(email);
+        if (value.isEmpty()) { // 만료된 경우
+            return false;
+        } else { // 만료되지 않은 경우
+            if (value.equals(certificationNumber)) {
+                return true; // 인증번호가 일치하는 경우
+            }
+            return false; // 인증번호가 일치하지 않는 경우
+        }
+    }
+
+    private void sendMail(String email, String content) throws MessagingException {
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
+        helper.setTo(email);
+        helper.setSubject("인증 메일 입니다.");
+        helper.setText(content);
+        javaMailSender.send(mimeMessage);
+    }
+}

--- a/src/main/java/com/dto/way/member/global/CertificationGenerator.java
+++ b/src/main/java/com/dto/way/member/global/CertificationGenerator.java
@@ -1,0 +1,22 @@
+package com.dto.way.member.global;
+
+import org.springframework.stereotype.Component;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+@Component
+public class CertificationGenerator {
+
+    public String createCertificationNumber() throws NoSuchAlgorithmException {
+
+        String result;
+
+        do {
+            int num = SecureRandom.getInstanceStrong().nextInt(999999);
+            result = String.valueOf(num);
+        } while (result.length() != 6);
+
+        return result;
+    }
+}

--- a/src/main/java/com/dto/way/member/global/JwtTokenProvider.java
+++ b/src/main/java/com/dto/way/member/global/JwtTokenProvider.java
@@ -53,7 +53,7 @@ public class JwtTokenProvider {
         log.info("authentication.getName() = {}", authentication.getName());
 
         // Access Token 생성
-        Date accessTokenExpiresIn = new Date(now + 60000);
+        Date accessTokenExpiresIn = new Date(now + 60000 * 30); // 30분
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("auth", authorities)
@@ -63,7 +63,7 @@ public class JwtTokenProvider {
 
         // Refresh Token 생성
         String refreshToken = Jwts.builder()
-                .setExpiration(new Date(now + 86400000))
+                .setExpiration(new Date(now + 86400000 * 7)) // 일주일
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 

--- a/src/main/java/com/dto/way/member/web/controller/MailRestController.java
+++ b/src/main/java/com/dto/way/member/web/controller/MailRestController.java
@@ -1,0 +1,43 @@
+package com.dto.way.member.web.controller;
+
+import com.dto.way.member.domain.service.MailService;
+import com.dto.way.member.web.dto.EmailCertificationRequest;
+import com.dto.way.member.web.response.ApiResponse;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.NoSuchAlgorithmException;
+
+import static com.dto.way.member.web.response.code.status.ErrorStatus.*;
+import static com.dto.way.member.web.response.code.status.SuccessStatus.*;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/member-service")
+public class MailRestController {
+
+    private final MailService mailSendService;
+
+    @PostMapping("/sendMailCertification")
+    public ApiResponse sendMailCertification(@Validated @RequestBody EmailCertificationRequest request) throws MessagingException, NoSuchAlgorithmException {
+
+        mailSendService.sendEmailForCertification(request.getEmail());
+        return ApiResponse.of(EMAIL_SENDED, null);
+    }
+
+    @GetMapping("/verify")
+    public ApiResponse verifyEmail(@RequestParam String email,
+                                     @RequestParam String certificationNumber) {
+
+        if (mailSendService.verifyEmail(email, certificationNumber)) {
+            return ApiResponse.of(EMAIL_VERIFIED, null);
+        } else {
+            return ApiResponse.onFailure(EMAIL_NOT_VERIFIED.getCode(), EMAIL_NOT_VERIFIED.getMessage(), null);
+        }
+
+    }
+}

--- a/src/main/java/com/dto/way/member/web/dto/EmailCertificationRequest.java
+++ b/src/main/java/com/dto/way/member/web/dto/EmailCertificationRequest.java
@@ -1,0 +1,17 @@
+package com.dto.way.member.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+public class EmailCertificationRequest {
+
+    @NotBlank(message = "이메일 입력은 필수입니다.")
+    @Email(message = "이메일 형식에 맞게 입력해주세요.")
+    private String email;
+}

--- a/src/main/java/com/dto/way/member/web/response/EmailCertificationResponse.java
+++ b/src/main/java/com/dto/way/member/web/response/EmailCertificationResponse.java
@@ -1,0 +1,14 @@
+package com.dto.way.member.web.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class EmailCertificationResponse {
+
+    private String email;
+    private String certificationNumber;
+}

--- a/src/main/java/com/dto/way/member/web/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/dto/way/member/web/response/code/status/ErrorStatus.java
@@ -17,14 +17,17 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // 회원가입 응답
-    MEMBER_NICKNAME_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBER4001", "유효한 닉네임이 아닙니다."),
-    MEMBER_NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "MEMBER4002", "중복된 닉네임 입니다."),
-    MEMBER_PASSWORD_NOT_VALID(HttpStatus.BAD_REQUEST, "MEMBER4003", "유효한 비밀번호가 아닙니다."),
-    MEMBER_PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "MEMBER4004", "비밀번호가 일치하지 않습니다."),
-    MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "MEMBER4005", "해당 이메일로 가입한 계정이 존재합니다."),
+    MEMBER_NICKNAME_NOT_VALID(HttpStatus.BAD_REQUEST, "SIGNUP4001", "유효한 닉네임이 아닙니다."),
+    MEMBER_NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "SIGNUP4002", "중복된 닉네임 입니다."),
+    MEMBER_PASSWORD_NOT_VALID(HttpStatus.BAD_REQUEST, "SIGNUP4003", "유효한 비밀번호가 아닙니다."),
+    MEMBER_PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "SIGNUP4004", "비밀번호가 일치하지 않습니다."),
+    MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "SIGNUP4005", "해당 이메일로 가입한 계정이 존재합니다."),
 
     // 로그인 응답
-    MEMBER_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "MEMBER40010", "아이디 또는 비밀번호가 일치하지 않습니다."),
+    MEMBER_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "LOGIN4001", "아이디 또는 비밀번호가 일치하지 않습니다."),
+
+    // 이메일 인증 응답
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "EMAIL4001", "인증번호가 일치하지 않습니다."),
     ;
 
 

--- a/src/main/java/com/dto/way/member/web/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/dto/way/member/web/response/code/status/SuccessStatus.java
@@ -25,8 +25,16 @@ public enum SuccessStatus implements BaseCode {
     //  게시글 관련 응답
     DAILY_CREATED(HttpStatus.OK, "DAILY2001", "Daily 게시글이 생성되었습니다."),
     DAILY_UPDATED(HttpStatus.OK,"DAILY2002","Daily 게시글이 수정되었습니다."),
-    DAILY_DELETED(HttpStatus.OK,"DAILY2003","Daily 게시글이 삭제되었습니다.")
+    DAILY_DELETED(HttpStatus.OK,"DAILY2003","Daily 게시글이 삭제되었습니다."),
+
+    // 이메일 인증 관련 응답
+    EMAIL_SENDED(HttpStatus.OK, "EMAIL2001", "인증 메일이 전송되었습니다."),
+    EMAIL_VERIFIED(HttpStatus.OK, "EMAIL2002", "이메일 인증이 완료되었습니다."),
+
+
     ;
+
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,15 @@ spring:
     redis:
       host: localhost
       port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        debug: true
+        smtp.auth: true
+        smtp.timeout: 60000 # 60000ms, 1분
+        smtp.starttls.enable: true
 cloud:
   aws:
     s3:


### PR DESCRIPTION


## 📌 요약

---
- 이메일 인증 기능이 구현 완료되었습니다.

## #️⃣ Issue Number or Link

---
DTO-159

## 📋 상세 내용

---
- 구글 SMTP를 통해 이메일 인증 기능을 구현했습니다.
- 메일 인증 유효시간은 10분 입니다.
- JWT 유효시간을 access token은 30분, refresh token은 7일로 재설정 했습니다.
- 이메일이 발송되기 까지 약 13초가 소요됩니다.

## ❓기타 문의사항

---

## ✔️PR Checklist 

---

PR이 다음 요구 사항을 충족하는지 확인하세요.

> Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
